### PR TITLE
[PI-14] Parse genesis utxo on start

### DIFF
--- a/blockchain-importer/README.md
+++ b/blockchain-importer/README.md
@@ -27,7 +27,7 @@ stack exec cardano-importer-swagger
 
 ## Run it
 
-**Pre-requesites**: `sudo apt-get install liblzma-dev libpq-dev`
+**Pre-requesites**: `sudo apt-get install liblzma-dev libpq-dev librocksdb-dev libssl-dev`
 
 Run it from project root.
 

--- a/blockchain-importer/cardano-sl-blockchain-importer.cabal
+++ b/blockchain-importer/cardano-sl-blockchain-importer.cabal
@@ -26,6 +26,7 @@ library
 
                         Pos.BlockchainImporter.Txp
 
+                        Pos.BlockchainImporter.Initialization
                         Pos.BlockchainImporter.Recovery
 
                         Pos.BlockchainImporter.Web

--- a/blockchain-importer/src/Pos/BlockchainImporter/Initialization.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Initialization.hs
@@ -1,0 +1,35 @@
+module Pos.BlockchainImporter.Initialization
+  ( -- * Initialization functions
+  initializePostgresDB
+  ) where
+
+import           Universum
+
+import           System.Wlog (WithLogger, logInfo)
+
+import           Pos.BlockchainImporter.Configuration (HasPostGresDB, postGreOperate)
+import qualified Pos.BlockchainImporter.Tables.BestBlockTable as BestBlockT
+import qualified Pos.BlockchainImporter.Tables.UtxosTable as UtxosT
+import           Pos.Core (HasGenesisData)
+import           Pos.Txp (genesisUtxo, unGenesisUtxo, utxoToModifier)
+
+type InitializationMode m =
+  ( MonadIO m
+  , WithLogger m
+  , HasPostGresDB
+  , HasGenesisData
+  )
+
+{-
+    Initializes postgres db to genesis block state, only when the db was previously not used:
+    - Genesis UTxOs are store
+    - Block number is set to 0
+-}
+initializePostgresDB :: InitializationMode m => m ()
+initializePostgresDB = do
+  postgresUtxos <- liftIO $ postGreOperate $ UtxosT.getUtxos
+  let genesisUtxos = unGenesisUtxo genesisUtxo
+  when (null postgresUtxos) $ do
+    liftIO $ postGreOperate $ UtxosT.applyModifierToUtxos $ utxoToModifier genesisUtxos
+    liftIO $ postGreOperate $ BestBlockT.updateBestBlock 0
+    logInfo "Initialized postgres db"

--- a/blockchain-importer/src/Pos/BlockchainImporter/Recovery.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Recovery.hs
@@ -128,7 +128,7 @@ rollbackPostgresDB rollbackTo = do
   liftIO $ postGreOperate $ BestBlockT.updateBestBlock rollbackTo
 
   liftIO $ postGreOperate $ UtxosT.clearUtxos
-  kvUtxos <- nonGenesisRocksUtxos
+  kvUtxos <- getAllPotentiallyHugeUtxo
   liftIO $ postGreOperate $ UtxosT.applyModifierToUtxos $ utxoToModifier kvUtxos
 
   logInfo $ sformat ("Rollbacked postgres db to block "%build) rollbackTo
@@ -148,12 +148,6 @@ blkNumberToRollback rocksBestBlock postgresBestBlock =
                                    else 0
   where latestCommonBlk = min rocksBestBlock postgresBestBlock
         maxRollback = fromIntegral blkSecurityParam
-
-nonGenesisRocksUtxos :: RecoveryMode ctx m => m Utxo
-nonGenesisRocksUtxos = do
-  allKVUtxos <- getAllPotentiallyHugeUtxo
-  let genesisUtxos = unGenesisUtxo genesisUtxo
-  pure $ allKVUtxos \\ genesisUtxos
 
 rocksDBTipDifficulty :: RecoveryMode ctx m => m BlockCount
 rocksDBTipDifficulty = getChainDifficulty . view difficultyL <$> DB.getTipHeader

--- a/blockchain-importer/src/Pos/BlockchainImporter/Recovery.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Recovery.hs
@@ -6,7 +6,6 @@ module Pos.BlockchainImporter.Recovery
 import           Universum
 
 import           Control.Lens (_Wrapped)
-import           Data.Map ((\\))
 import           Formatting (build, int, sformat, (%))
 import           JsonLog (CanJsonLog (..))
 import           System.Wlog (logInfo, logWarning)
@@ -25,7 +24,7 @@ import qualified Pos.DB.Block.Load as DB
 import qualified Pos.DB.BlockIndex as DB
 import           Pos.Ssc.Configuration (HasSscConfiguration)
 import           Pos.StateLock (Priority (..), StateLock, StateLockMetrics, withStateLock)
-import           Pos.Txp (Utxo, genesisUtxo, unGenesisUtxo, utxoToModifier)
+import           Pos.Txp (utxoToModifier)
 import           Pos.Txp.DB (getAllPotentiallyHugeUtxo)
 import           Pos.Util.Chrono (NewestFirst, _NewestFirst)
 import           Pos.Util.JsonLog.Events (MemPoolModifyReason (..))

--- a/blockchain-importer/src/blockchain-importer/Main.hs
+++ b/blockchain-importer/src/blockchain-importer/Main.hs
@@ -23,6 +23,7 @@ import           Pos.Binary ()
 import           Pos.BlockchainImporter.Configuration (HasPostGresDB, withPostGreTransaction,
                                                        withPostGresDB)
 import           Pos.BlockchainImporter.ExtraContext (makeExtraCtx)
+import           Pos.BlockchainImporter.Initialization (initializePostgresDB)
 import           Pos.BlockchainImporter.Recovery (recoverDBsConsistency)
 import           Pos.BlockchainImporter.Tables.TxsTable (markPendingTxsAsFailed)
 import           Pos.BlockchainImporter.Txp (BlockchainImporterExtraModifier,
@@ -105,11 +106,13 @@ action (BlockchainImporterNodeArgs (cArgs@CommonNodeArgs{..}) BlockchainImporter
             elim = elimRealMode nr
             ekgNodeMetrics = EkgNodeMetrics
                 nrEkgStore
-            startImporter = runServer
-              (runProduction . elim . blockchainImporterModeToRealMode)
-              ncNodeParams
-              ekgNodeMetrics
-              go
+            startImporter = do
+              initializePostgresDB
+              runServer
+                (runProduction . elim . blockchainImporterModeToRealMode)
+                ncNodeParams
+                ekgNodeMetrics
+                go
             serverRealMode = blockchainImporterModeToRealMode $
               if recoveryMode then do
                   recoverDBsConsistency


### PR DESCRIPTION
## Description

Updates importer codebase to parse genesis txs and store them to the postgres db. This is done on start-up, initializing the postgres db appropriately to start on a genesis block state.

## Testing

Importer was started to store only initalized data, and UTxOs on Postgres DB were checked for consistency with [expected ones](https://github.com/input-output-hk/cardano-sl/blob/master/lib/mainnet-genesis.json).

Due to addresses stored on DB being a derived from the public keys stored on the linked JSON file, the following checks were done so far:
- Checked that obtained UTxO's receiver addresses sent redeem txs (i.e. https://cardanoexplorer.com/address/Ae2tdPwUPEYwkJ3PcvSiqiVt1rNctVs4HbWz6poysDuD1ouaKrbXFFmjieC)
- Checked that genesis UTxO size was equal to expected length
- Checked that funds from expected UTxO's receivers had associated addresses in DB

## Updating production

As the current production DB doesn't have the UTxO for redeem there're 2 options for updating it:
- Re-deploying the backend and importer and changing the backend used by the fronted: This only has pre-production costs, as 7 hours are required for getting the importer up-to-date with the current Cardano blockchain.
- Stopping the current importer, restarting it from the new version with recovery mode enabled: This requires production to be running for 10 minutes during which recompilation, getting the UTxO with reedem ones and syncing to the top are done. 

## Linked issue

https://trello.com/c/UQIGJxEc

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
